### PR TITLE
Orcid two factor authentication

### DIFF
--- a/forms/OpenIDPluginSettingsForm.inc.php
+++ b/forms/OpenIDPluginSettingsForm.inc.php
@@ -87,6 +87,7 @@ class OpenIDPluginSettingsForm extends Form
 				'generateAPIKey' => $settings['generateAPIKey'] ? $settings['generateAPIKey'] : 0,
 				'providerSync' => key_exists('providerSync', $settings) ? $settings['providerSync'] : false,
 				'disableFields' => $settings['disableFields'],
+				'orcid2fa' => key_exists('orcid2fa', $settings) ? $settings['orcid2fa'] : false,
 			);
 		} else {
 			$this->_data = array(
@@ -105,7 +106,7 @@ class OpenIDPluginSettingsForm extends Form
 	function readInputData()
 	{
 		$this->readUserVars(
-			array('provider', 'legacyLogin', 'legacyRegister', 'disableConnect', 'hashSecret', 'generateAPIKey', 'providerSync', 'disableFields')
+			array('provider', 'legacyLogin', 'legacyRegister', 'disableConnect', 'hashSecret', 'generateAPIKey', 'providerSync', 'disableFields', 'orcid2fa')
 		);
 		parent::readInputData();
 	}
@@ -157,6 +158,7 @@ class OpenIDPluginSettingsForm extends Form
 			'generateAPIKey' => $this->getData('generateAPIKey'),
 			'providerSync' => $this->getData('providerSync'),
 			'disableFields' => $this->getData('disableFields'),
+			'orcid2fa' => $this->getData('orcid2fa'),
 		);
 		$this->plugin->updateSetting($contextId, 'openIDSettings', json_encode($settings), 'string');
 		import('classes.notification.NotificationManager');

--- a/handler/OpenIDHandler.inc.php
+++ b/handler/OpenIDHandler.inc.php
@@ -75,8 +75,8 @@ class OpenIDHandler extends Handler
 
 		if (isset($token) && isset($publicKey)) {
 			$tokenPayload = $this->_validateAndExtractToken($token, $publicKey);
-                        //CUL customization: require two-factor authentication
-                        if ($tokenPayload['amr'] != 'mfa') {
+                        //check if orcid two-factor authentication is required
+                        if ($settings['orcid2fa'] == true && $tokenPayload['amr'] != 'mfa') {
 				$ssoErrors['sso_error'] = '2fa';
                 		return $request->redirect($context, 'login', null, null, $ssoErrors);
 			}
@@ -404,7 +404,7 @@ class OpenIDHandler extends Handler
 								'given_name' => property_exists($jwtPayload, 'given_name') ? $jwtPayload->given_name : null,
 								'family_name' => property_exists($jwtPayload, 'family_name') ? $jwtPayload->family_name : null,
 								'email_verified' => property_exists($jwtPayload, 'email_verified') ? $jwtPayload->email_verified : null,
-						//Cul customization: extracting amr attribute 
+						//orcid property for checking two factor authentication status 
 								'amr' => property_exists($jwtPayload, 'amr') ? $jwtPayload->amr : null,
 							];
 						}

--- a/handler/OpenIDHandler.inc.php
+++ b/handler/OpenIDHandler.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-//$loader = require('plugins/generic/openid/vendor/autoload.php');
+$loader = require('plugins/generic/openid/vendor/autoload.php');
 
 use Firebase\JWT\JWT;
 use GuzzleHttp\Exception\GuzzleException;

--- a/handler/OpenIDHandler.inc.php
+++ b/handler/OpenIDHandler.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-$loader = require('plugins/generic/openid/vendor/autoload.php');
+//$loader = require('plugins/generic/openid/vendor/autoload.php');
 
 use Firebase\JWT\JWT;
 use GuzzleHttp\Exception\GuzzleException;
@@ -75,6 +75,11 @@ class OpenIDHandler extends Handler
 
 		if (isset($token) && isset($publicKey)) {
 			$tokenPayload = $this->_validateAndExtractToken($token, $publicKey);
+                        //CUL customization: require two-factor authentication
+                        if ($tokenPayload['amr'] != 'mfa') {
+				$ssoErrors['sso_error'] = '2fa';
+                		return $request->redirect($context, 'login', null, null, $ssoErrors);
+			}
 			if (isset($tokenPayload) && is_array($tokenPayload)) {
 				$tokenPayload['selectedProvider'] = $selectedProvider;
 				$user = $this->_getUserViaKeycloakId($tokenPayload);
@@ -391,7 +396,6 @@ class OpenIDHandler extends Handler
 				try {
 					if (!empty($t)) {
 						$jwtPayload = JWT::decode($t, $publicKey, array('RS256'));
-
 						if (isset($jwtPayload)) {
 							$credentials = [
 								'id' => property_exists($jwtPayload, 'sub') ? $jwtPayload->sub : null,
@@ -400,6 +404,8 @@ class OpenIDHandler extends Handler
 								'given_name' => property_exists($jwtPayload, 'given_name') ? $jwtPayload->given_name : null,
 								'family_name' => property_exists($jwtPayload, 'family_name') ? $jwtPayload->family_name : null,
 								'email_verified' => property_exists($jwtPayload, 'email_verified') ? $jwtPayload->email_verified : null,
+						//Cul customization: extracting amr attribute 
+								'amr' => property_exists($jwtPayload, 'amr') ? $jwtPayload->amr : null,
 							];
 						}
 						if (isset($credentials) && key_exists('id', $credentials) && !empty($credentials['id'])) {

--- a/handler/OpenIDLoginHandler.inc.php
+++ b/handler/OpenIDLoginHandler.inc.php
@@ -66,7 +66,7 @@ class OpenIDLoginHandler extends Handler
 					foreach ($providerList as $name => $settings) {
 						if (key_exists('authUrl', $settings) && !empty($settings['authUrl'])
 							&& key_exists('clientId', $settings) && !empty($settings['clientId'])) {
-				//CUL customization: if there is a single provider, make sure there are no login errors before redirecting
+				//if there is a single provider, make sure there are no login errors before redirecting
 				$ssoErrorCheck = $request->getUserVar('sso_error');
 				if (sizeof($providerList) == 1 && !$legacyLogin && !$legacyRegister && !isset($ssoErrorCheck) && empty($ssoErrorCheck)) {
 								$request->redirectUrl(
@@ -224,7 +224,7 @@ class OpenIDLoginHandler extends Handler
 				$templateMgr->assign('errorMsg', 'plugins.generic.openid.error.openid.cert.desc');
 				break;
 			case '2fa':
-                                $templateMgr->assign('errorMsg', 'plugins.generic.openid.error.openid.twofa.desc');
+                                $templateMgr->assign('errorMsg', 'plugins.generic.openid.error.openid.orcid2fa.desc');
 				break;
 			case 'disabled':
 				$reason = $request->getUserVar('sso_error_msg');

--- a/handler/OpenIDLoginHandler.inc.php
+++ b/handler/OpenIDLoginHandler.inc.php
@@ -51,7 +51,6 @@ class OpenIDLoginHandler extends Handler
 		$legacyLogin = false;
 		$templateMgr = TemplateManager::getManager($request);
 		$context = $request->getContext();
-
 		if (!Validation::isLoggedIn()) {
 			$router = $request->getRouter();
 			$contextId = ($context == null) ? 0 : $context->getId();
@@ -67,7 +66,9 @@ class OpenIDLoginHandler extends Handler
 					foreach ($providerList as $name => $settings) {
 						if (key_exists('authUrl', $settings) && !empty($settings['authUrl'])
 							&& key_exists('clientId', $settings) && !empty($settings['clientId'])) {
-							if (sizeof($providerList) == 1 && !$legacyLogin && !$legacyRegister) {
+				//CUL customization: if there is a single provider, make sure there are no login errors before redirecting
+				$ssoErrorCheck = $request->getUserVar('sso_error');
+				if (sizeof($providerList) == 1 && !$legacyLogin && !$legacyRegister && !isset($ssoErrorCheck) && empty($ssoErrorCheck)) {
 								$request->redirectUrl(
 									$settings['authUrl'].
 									'?client_id='.$settings['clientId'].
@@ -221,6 +222,9 @@ class OpenIDLoginHandler extends Handler
 				break;
 			case 'cert':
 				$templateMgr->assign('errorMsg', 'plugins.generic.openid.error.openid.cert.desc');
+				break;
+			case '2fa':
+                                $templateMgr->assign('errorMsg', 'plugins.generic.openid.error.openid.twofa.desc');
 				break;
 			case 'disabled':
 				$reason = $request->getUserVar('sso_error_msg');

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -123,6 +123,9 @@ msgstr "Please enter the label of the login button."
 msgid "plugins.generic.openid.settings.orcid.enable"
 msgstr "ORCID OpenID Connect"
 
+msgid "plugins.generic.openid.settings.orcid.orcid2fa.enable"
+msgstr "Require Two-Factor Authentication for OrcId login"
+
 msgid "plugins.generic.openid.settings.orcid.desc"
 msgstr "Please use this redirect URL (see <a href='https://github.com/ORCID/ORCID-Source/blob/master/orcid-web/ORCID_AUTH_WITH_OPENID_CONNECT.md' target='_blank' rel='noopener'>tutorial</a>):"
 
@@ -237,7 +240,7 @@ msgstr "<strong>An error occurred while receiving your data from the OpenId prov
 msgid "plugins.generic.openid.error.openid.cert.desc"
 msgstr "<strong>An error occurred while validation and extracting your data.</strong><br />The service may not be available right now.<br />Please try again later and <a href='mailto:{$supportEmail}'>contact technical support</a> if the problem still exists."
 
-msgid "plugins.generic.openid.error.openid.twofa.desc"
+msgid "plugins.generic.openid.error.openid.orcid2fa.desc"
 msgstr "Orcid two-factor authentication is required for login. Please go to <a href=\"https://orcid.org\">orcid.org</a>, log into your Orcid profile and turn on two-factor authentication in the security section of your account settings."
 
 msgid "plugins.generic.openid.error.openid.disabled.without"

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -237,6 +237,9 @@ msgstr "<strong>An error occurred while receiving your data from the OpenId prov
 msgid "plugins.generic.openid.error.openid.cert.desc"
 msgstr "<strong>An error occurred while validation and extracting your data.</strong><br />The service may not be available right now.<br />Please try again later and <a href='mailto:{$supportEmail}'>contact technical support</a> if the problem still exists."
 
+msgid "plugins.generic.openid.error.openid.twofa.desc"
+msgstr "Orcid two-factor authentication is required for login. Please go to <a href=\"https://orcid.org\">orcid.org</a>, log into your Orcid profile and turn on two-factor authentication in the security section of your account settings."
+
 msgid "plugins.generic.openid.error.openid.disabled.without"
 msgstr "<strong>This account is disabled without any specific reason.</strong><br />Please <a href='mailto:{$supportEmail}'>contact technical support</a> to enable this account."
 

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -105,6 +105,10 @@
 						{else}
 							{fbvElement type="hidden" id="provider[{$name}][configUrl]" value=$settings['configUrl'] }
 						{/if}
+						{if $name eq 'orcid'}
+							{fbvElement type="checkbox" name="orcid2fa" id="orcid2fa" checked=$orcid2fa value="1" label="plugins.generic.openid.settings.orcid.orcid2fa.enable"}
+							<div style="clear: both;">&nbsp;</div>
+						{/if}
 						<div>
 							<div><strong>{translate key="plugins.generic.openid.settings.provider.settings"}</strong></div>
 							{fbvElement type="text" id="provider[{$name}][clientId]" value=$provider[{$name}]['clientId'] maxlength="250" label="plugins.generic.openid.settings.clientId.desc" inline=true size=$fbvStyles.size.MEDIUM}


### PR DESCRIPTION
Thanks for your work on this plugin. We will be using it on our OJS instance with OrcId as our openid provider, but in addition, we are requiring our users to enable 2FA in their OrcId accounts. The code in this PR enforces the 2FA requirement and adds this option to the OrcId section of the settings form.

Also, I was able to get the plugin working without requiring the vendor autoloader.php file on line 3 of OpenIDHandler. I'm not sure if I’m missing something important there or if that is leftover from a previous approach.

-Jack
